### PR TITLE
[WIP] Verify Transaction Signatures Before Updating During Mempool Syncing

### DIFF
--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -52,4 +52,6 @@ pub enum NodeError {
     HandshakeClientMismatch,
     #[error("remote server error: {0}")]
     RemoteServerError(String),
+    #[error("signature verification failed")]
+    SignatureVerification,
 }

--- a/src/node/api/post_mpn_deposit.rs
+++ b/src/node/api/post_mpn_deposit.rs
@@ -8,6 +8,9 @@ pub async fn post_mpn_deposit<B: Blockchain>(
     context: Arc<RwLock<NodeContext<B>>>,
     req: PostMpnDepositRequest,
 ) -> Result<PostMpnDepositResponse, NodeError> {
+    if !req.tx.payment.verify_signature() {
+        return Err(NodeError::SignatureVerification);
+    }
     let mut context = context.write().await;
     let now = context.local_timestamp();
     context

--- a/src/node/api/transact.rs
+++ b/src/node/api/transact.rs
@@ -8,7 +8,6 @@ pub async fn transact<B: Blockchain>(
     context: Arc<RwLock<NodeContext<B>>>,
     req: TransactRequest,
 ) -> Result<TransactResponse, NodeError> {
-    // verify first before locking
     if req.tx_delta.tx.verify_signature() {
         return Err(NodeError::SignatureVerification);
     }

--- a/src/node/api/transact.rs
+++ b/src/node/api/transact.rs
@@ -8,6 +8,10 @@ pub async fn transact<B: Blockchain>(
     context: Arc<RwLock<NodeContext<B>>>,
     req: TransactRequest,
 ) -> Result<TransactResponse, NodeError> {
+    // verify first before locking
+    if req.tx_delta.tx.verify_signature() {
+        return Err(NodeError::SignatureVerification);
+    }
     let mut context = context.write().await;
     let now = context.local_timestamp();
     context

--- a/src/node/heartbeat/sync_mempool.rs
+++ b/src/node/heartbeat/sync_mempool.rs
@@ -58,8 +58,10 @@ pub async fn sync_mempool<B: Blockchain>(
             }
             for tx in zk_s.into_iter().filter(|tx| {
                 if !tx.verify(&tx.dst_pub_key) {
-                    log::warn!("zk_s tx {:?} is not valid", tx.sig);
-                    false
+                    log::debug!("zk_s tx {:?} is not valid", tx.sig);
+                    // todo: just log for now
+                    //false
+                    true
                 } else {
                     true
                 }


### PR DESCRIPTION
# Overview

Whenever updating the mempool, verify transaction signatures before update; This will prevent honest peers from propagating invalid transactions that deserialize from the api correctly, but otherwise are not cryptographically valid.

# WIP

* figure out correct validation for `ctx.mempool.zk_tx` signature verification
* figure out correct validation for `ctx.mempool.zx` signature verification
* validate all signatures through api submission, atm only regular transactions are validated